### PR TITLE
mesh parser; left strip "NAME =" line prefix

### DIFF
--- a/parsers.py
+++ b/parsers.py
@@ -612,17 +612,17 @@ class MESHParser(Parser):
 		with open(self._url, 'r') as fp:
 			for line in fp.readlines():
 				if line.startswith('MH ='):
-					mh = line.split('=')[1].strip()
+					mh = line.lstrip('MH =').strip()
 				elif line.startswith('UI ='):
-					ui = line.split('=')[1].strip()
+					ui = line.lstrip('UI =').strip()
 				elif line.startswith('MN ='):
-					mn = line.split('=')[1].strip()
+					mn = line.lstrip('MN =').strip()
 					mns.add(mn)
 				elif line.startswith('ST ='):
-					st = line.split('=')[1].strip()
+					st = line.lstrip('ST =').strip()
 					sts.add(st)
 				elif line.startswith('PRINT ENTRY ='):
-					entry = line.split('=')[1].strip()
+					entry = line.lstrip('PRINT ENTRY =').strip()
 					if '|EQV|' in line:
 						entries = entry.split('|')
 						last = entries[-1]
@@ -635,7 +635,7 @@ class MESHParser(Parser):
 						if '|' not in entry:
 							synonyms.add(entry)
 				elif line.startswith('ENTRY ='):
-					entry = line.split('=')[1].strip()
+					entry = line.lstrip('ENTRY =').strip()
 					if '|EQV|' in line:
 						entries = entry.split('|')
 						last = entries[-1]


### PR DESCRIPTION
@ncatlett This seems to address MESH parsing issues experienced in [build #239](http://build.openbel.org/browse/OR-BR-239).

'=' may exist in the line multiple times so lstrip will be safer

mesh entry causing error:
ENTRY = Cerebral Ventricular System(term_ui=T000860463)|T030|NON|EQV|NLM
(2015)|140610|abcdef
